### PR TITLE
Contact and MarketingData components transition from React to Next

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "13.0.2",
         "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "react-dom": "18.2.0",
+        "swiper": "^8.4.4"
       }
     },
     "node_modules/@next/env": {
@@ -241,6 +242,14 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
+    "node_modules/dom7": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.4.tgz",
+      "integrity": "sha512-DSSgBzQ4rJWQp1u6o+3FVwMNnT5bzQbMb+o31TjYYeRi05uAcpF8koxdfzeoe5ElzPmua7W7N28YJhF7iEKqIw==",
+      "dependencies": {
+        "ssr-window": "^4.0.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -387,6 +396,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssr-window": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
+      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ=="
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.0.tgz",
@@ -407,6 +421,29 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/swiper": {
+      "version": "8.4.4",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.4.tgz",
+      "integrity": "sha512-jA/8BfOZwT8PqPSnMX0TENZYitXEhNa7ZSNj1Diqh5LZyUJoBQaZcqAiPQ/PIg1+IPaRn/V8ZYVb0nxHMh51yw==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "hasInstallScript": true,
+      "dependencies": {
+        "dom7": "^4.0.4",
+        "ssr-window": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/tslib": {
@@ -525,6 +562,14 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
+    "dom7": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.4.tgz",
+      "integrity": "sha512-DSSgBzQ4rJWQp1u6o+3FVwMNnT5bzQbMb+o31TjYYeRi05uAcpF8koxdfzeoe5ElzPmua7W7N28YJhF7iEKqIw==",
+      "requires": {
+        "ssr-window": "^4.0.0"
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -614,12 +659,26 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
     },
+    "ssr-window": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
+      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ=="
+    },
     "styled-jsx": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.0.tgz",
       "integrity": "sha512-/iHaRJt9U7T+5tp6TRelLnqBqiaIT0HsO0+vgyj8hK2KUk7aejFqRrumqPUlAqDwAj8IbS/1hk3IhBAAK/FCUQ==",
       "requires": {
         "client-only": "0.0.1"
+      }
+    },
+    "swiper": {
+      "version": "8.4.4",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.4.tgz",
+      "integrity": "sha512-jA/8BfOZwT8PqPSnMX0TENZYitXEhNa7ZSNj1Diqh5LZyUJoBQaZcqAiPQ/PIg1+IPaRn/V8ZYVb0nxHMh51yw==",
+      "requires": {
+        "dom7": "^4.0.4",
+        "ssr-window": "^4.0.2"
       }
     },
     "tslib": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "next": "13.0.2",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "swiper": "^8.4.4"
   }
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,10 +1,11 @@
 import '../styles/globals.css'
 
-import Banner from './components/Banner';
 import Navbar from './components/Navbar';
+import Banner from './components/Banner';
+import WhatWeDo from './components/WhatWeDo';
 import Costumers from './components/Costumers';
 import MarketingData from './components/MarketingData';
-import WhatWeDo from './components/WhatWeDo';
+import Contact from './components/Contact';
 import Footer from './components/Footer';
 
 function MyApp() {
@@ -15,6 +16,7 @@ function MyApp() {
       <WhatWeDo/>
       <Costumers/>
       <MarketingData/>
+      <Contact/>
       <Footer/>
     </>
   )

--- a/pages/components/Contact/index.js
+++ b/pages/components/Contact/index.js
@@ -1,0 +1,52 @@
+import styles from "./index.module.css";
+
+// Function to create an auto-resizing textarea
+
+// const textArea = document.getElementsByTagName("textarea");
+// for (let i = 0; i < textArea.length; i++) {
+//   textArea[i].setAttribute("style", "height: " + (textArea[i].scrollHeight) + "px; overflow-y: scroll;");
+//   textArea[i].addEventListener("input", OnInput, false);
+// }
+
+// function OnInput() {
+//   this.style.height = 0;
+//   this.style.height = (this.scrollHeight) + "px";
+// }
+
+export default function Contact() {
+  return (
+    <section id={styles.contactPage}>
+      <div id={styles.contactTitleBlock}>
+        <h2 id={styles.contactTitle}>Vamos bater um papo?</h2>
+      </div>
+      <form id={styles.contactForm}>
+        <label className={styles.contactFormLabel}>
+          <h3 className={styles.formTitles}>Nome</h3>
+          <input type="text" className={styles.formInput} required />
+        </label>
+        <label className={styles.contactFormLabel}>
+          <h3 className={styles.formTitles}>Empresa</h3>
+          <input type="text" className={styles.formInput} required />
+        </label>
+        <label className={styles.contactFormLabel}>
+          <h3 className={styles.formTitles}>Tamanho da empresa</h3>
+          <select id={styles.multiSelection} className={styles.formInput} required>
+            <option value="less-than-ten">Menos de 10 funcionários</option>
+            <option value="up-to-ten">Até 10 funcionários</option>
+            <option value="more-than-ten">Mais de 10 funcionários</option>
+          </select>
+        </label>
+        <label className={styles.contactFormLabel}>
+          <h3 className={styles.formTitles}>E-mail</h3>
+          <input type="email" className={styles.formInput} required />
+        </label>
+        <label className={styles.contactFormLabel}>
+          <h3 className={styles.formTitles}>Mensagem</h3>
+          <textarea className={styles.formInput} id={styles.desktop} placeholder="Conte-nos um pouco do que precisa" rows="1" required></textarea>
+          <textarea className={styles.formInput} id={styles.mobile} placeholder="Conte-nos o que precisa" rows="1" required></textarea>
+        </label>
+        <button id={styles.contactCta}>BORA CONVERSAR!</button>
+      </form>
+    </section>
+  )
+}

--- a/pages/components/Contact/index.js
+++ b/pages/components/Contact/index.js
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import styles from "./index.module.css";
 
 // Function to create an auto-resizing textarea
@@ -14,39 +16,95 @@ import styles from "./index.module.css";
 // }
 
 export default function Contact() {
+
+  const [name, setName] = useState('')
+  const [company, setCompany] = useState('')
+  const [companySize, setCompanySize] = useState('up-to-ten')
+  const [email, setEmail] = useState('')
+  const [message, setMessage] = useState('')
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const postTest = { name, company, companySize, email, message };
+    console.log(postTest)
+  }
+
   return (
     <section id={styles.contactPage}>
+
       <div id={styles.contactTitleBlock}>
         <h2 id={styles.contactTitle}>Vamos bater um papo?</h2>
       </div>
-      <form id={styles.contactForm}>
+
+      <form id={styles.contactForm} onSubmit={handleSubmit}>
         <label className={styles.contactFormLabel}>
-          <h3 className={styles.formTitles}>Nome</h3>
-          <input type="text" className={styles.formInput} required />
+          <h3 className={styles.formTitle}>Nome</h3>
+          <input 
+            type="text"
+            className={styles.formInput}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
         </label>
         <label className={styles.contactFormLabel}>
-          <h3 className={styles.formTitles}>Empresa</h3>
-          <input type="text" className={styles.formInput} required />
+          <h3 className={styles.formTitle}>Empresa</h3>
+          <input
+            type="text"
+            className={styles.formInput}
+            value={company}
+            onChange={(e) => setCompany(e.target.value)}
+            required
+          />
         </label>
         <label className={styles.contactFormLabel}>
-          <h3 className={styles.formTitles}>Tamanho da empresa</h3>
-          <select id={styles.multiSelection} className={styles.formInput} required>
-            <option value="less-than-ten">Menos de 10 funcionários</option>
+          <h3 className={styles.formTitle}>Tamanho da empresa</h3>
+          <select
+            id={styles.multiSelection}
+            className={styles.formInput}
+            value={companySize}
+            onChange={(e) => setCompanySize(e.target.value)}
+            required
+          >
             <option value="up-to-ten">Até 10 funcionários</option>
-            <option value="more-than-ten">Mais de 10 funcionários</option>
+            <option value="between-ten-and-fifty">Entre 10 e 50 funcionários</option>
+            <option value="more-than-fifty">Acima de 50 funcionários</option>
           </select>
         </label>
         <label className={styles.contactFormLabel}>
-          <h3 className={styles.formTitles}>E-mail</h3>
-          <input type="email" className={styles.formInput} required />
+          <h3 className={styles.formTitle}>E-mail</h3>
+          <input
+            type="email"
+            className={styles.formInput}
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
         </label>
         <label className={styles.contactFormLabel}>
-          <h3 className={styles.formTitles}>Mensagem</h3>
-          <textarea className={styles.formInput} id={styles.desktop} placeholder="Conte-nos um pouco do que precisa" rows="1" required></textarea>
-          <textarea className={styles.formInput} id={styles.mobile} placeholder="Conte-nos o que precisa" rows="1" required></textarea>
+          <h3 className={styles.formTitle}>Mensagem</h3>
+          <textarea
+            className={styles.formInput}
+            id={styles.desktop}
+            placeholder="Conte-nos um pouco do que precisa"
+            rows="1"
+            required
+            value={message} 
+            onChange={(e) => setMessage(e.target.value)}
+          ></textarea>
+          <textarea
+            className={styles.formInput}
+            id={styles.mobile}
+            placeholder="Conte-nos o que precisa"
+            rows="1"
+            required
+            value={message} 
+            onChange={(e) => setMessage(e.target.value)}
+          ></textarea>
         </label>
         <button id={styles.contactCta}>BORA CONVERSAR!</button>
       </form>
+
     </section>
   )
 }

--- a/pages/components/Contact/index.module.css
+++ b/pages/components/Contact/index.module.css
@@ -46,7 +46,7 @@
   box-sizing: border-box;
 }
 
-.formTitles,
+.formTitle,
 textarea#desktop::placeholder,
 textarea#mobile::placeholder {
   font-style: normal;

--- a/pages/components/Contact/index.module.css
+++ b/pages/components/Contact/index.module.css
@@ -1,0 +1,196 @@
+/* Contact page and its pink block with title */
+
+#contactPage {
+  display: flex;
+  justify-content: center;
+
+  background-color: #FAFAFA;
+
+  padding: 0 24px;
+}
+
+#contactTitleBlock {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 479px;
+  height: 768px;
+
+  margin-right: 72px;
+
+  background-color: #FF4D97;
+}
+
+#contactTitle {
+  font-style: normal;
+  font-weight: 800;
+  font-size: 32px;
+  line-height: 38px;
+  text-align: center;
+  color: #FFFFFF;
+
+  width: 257px;
+}
+
+/* Formulary */
+
+#contactForm {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+
+  width: 479px;
+  height: 768px;
+
+  box-sizing: border-box;
+}
+
+.formTitles,
+textarea#desktop::placeholder,
+textarea#mobile::placeholder {
+  font-style: normal;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 38px;
+
+  margin: 0 0 6px;
+  padding-left: 2px;
+}
+
+textarea#desktop::placeholder,
+textarea#mobile::placeholder {
+  font-weight: 400;
+  line-height: 26px;
+
+  margin: 0;
+
+  color: #000;
+}
+
+.formInput {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid;
+  box-sizing: border-box;
+
+  width: 411px;
+  margin-bottom: 24px;
+  padding: 0 4px;
+
+  outline: none;
+}
+
+.formInput:focus {
+  border-bottom: 4px solid #262626;
+}
+
+.formInput[type="text"], 
+.formInput[type="email"], 
+select#multiSelection {
+  font-style: normal;
+  font-size: 16px;
+  line-height: 26px;
+
+  padding: 0;
+}
+
+textarea#desktop, textarea#mobile {
+  font-style: normal;
+  font-size: 16px;
+
+  resize: none;
+
+  min-height: 28px;
+
+  margin-bottom: 40px;
+
+  overflow-y: scroll;
+}
+
+textarea#mobile {
+display: none;
+}
+
+/* Button */
+
+#contactCta {
+  cursor: pointer;
+
+  font-style: normal;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 24px;
+  color: #FFF;
+  text-decoration: none;
+
+  background: linear-gradient(90deg, #E10072 23.83%, #E10072 77.54%);
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.15);
+  border: none;
+  border-radius: 33px;
+
+  width: 203px;
+  height: 56px;
+}
+
+/* Button animation idea: to indicate it's clickable, besides the cursor pointer */
+
+#contactCta:hover {
+  color: #E10072;
+
+  background: linear-gradient(90deg, #FFF 23.83%, #FFF 77.54%);
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+/* Mobile version */
+
+@media screen and (max-width: 939px) {
+  #contactPage {
+      display: block;
+
+      padding: 0;
+  }
+
+  #contactTitleBlock {
+      width: 85%;
+      height: 132px;
+
+      margin-top: 25px;
+}
+
+  #contactTitle {
+      font-size: 24px;
+      line-height: 30px;
+  }
+
+  /* Formulary mobile */
+
+  #contactForm {
+      align-items: center;
+
+      width: auto;
+      max-width: 361px;
+      max-height: 673px;
+
+      margin: 0 auto;
+      padding: 0 24px;
+  }
+
+  .formInput {
+      width: 288px;
+  }
+
+  textarea#desktop {
+      display: none;
+  }
+
+  textarea#mobile {
+      display: inline-block;
+  }
+
+  /* Button mobile */
+
+  #contactCta {
+      align-self: center;
+  }
+}

--- a/pages/components/Costumers/index.module.css
+++ b/pages/components/Costumers/index.module.css
@@ -22,6 +22,8 @@
     padding-bottom: 138px;
 }
 
+/* Mobile version */
+
 @media screen and (max-width: 699px) {
     .costumersTitle {
       font-size: 24px;

--- a/pages/components/MarketingData/index.js
+++ b/pages/components/MarketingData/index.js
@@ -1,6 +1,17 @@
+import { useRef }from 'react';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Navigation } from 'swiper';
+
+// Import Swiper styles
+import 'swiper/css';
+import 'swiper/css/navigation';
+
 import styles from "./index.module.css";
 
 export default function MarketingData() {
+
+  const swiperRef = useRef();
+
   return (
     <section id={styles.marketingData}>
       <h2 id={styles.marketingDataTitle}>Por que usar o marketing de influência?</h2>
@@ -18,6 +29,35 @@ export default function MarketingData() {
           <p className={styles.marketingDataPercentages} id={styles.thirdPercentage}>55%</p>
           <p className={styles.marketingDataText}>acham que recomendações feitas por influencers são menos invasivas do que os anúncios na internet e TV</p>
         </div>
+      </div>
+
+      <div id={styles.carouselWrapper}>
+        <button className={styles.swiperButton} id={styles.prev} onClick={() => swiperRef.current?.slidePrev()}></button>
+      
+        <Swiper 
+        modules={[Navigation]}
+        id={styles.mySwiper}
+        initialSlide="1"
+        navigation={true}
+        onBeforeInit={(swiper) => {
+          swiperRef.current = swiper;
+          }
+        }>
+          <SwiperSlide>
+            <p className={styles.marketingDataPercentages} id={styles.firstPercentage}>76%</p>
+            <p className={styles.marketingDataText}>dos usuários já compraram algo por meio de indicação de influenciadores</p>
+          </SwiperSlide>
+          <SwiperSlide>
+            <p className={styles.marketingDataPercentages} id={styles.secondPercentage}>50%</p>
+            <p className={styles.marketingDataText}>costuma pesquisar a opinião de influenciadores digitais antes de comprar produtos e serviços</p>
+          </SwiperSlide>
+          <SwiperSlide>
+            <p className={styles.marketingDataPercentages} id={styles.thirdPercentage}>55%</p>
+            <p className={styles.marketingDataText}>acham que recomendações feitas por influencers são menos invasivas do que os anúncios na internet e TV</p>
+          </SwiperSlide>
+        </Swiper>
+  
+        <button className={styles.swiperButton} id={styles.next} onClick={() => swiperRef.current?.slideNext()}></button>
       </div>
 
       <p className={styles.marketingDataText} id={styles.studySource}>Estudo realizado pelo Instituto Qualibest</p>

--- a/pages/components/MarketingData/index.module.css
+++ b/pages/components/MarketingData/index.module.css
@@ -1,5 +1,4 @@
 #marketingData { 
-  font-family: 'Poppins';
   font-style: normal;
 
   background: #FFA020; 
@@ -17,6 +16,8 @@
     margin: 0 auto 80px;
     padding-top: 80px;
 }
+
+/* Cards section */
 
 #marketingDataWrapper {
     display: flex;
@@ -42,7 +43,7 @@
     /* transition: 0.3s; */
 }
 
-/* #marketing-data-wrapper > *:hover {
+/* #marketingDataWrapper > *:hover {
     Card styling idea: deeper shadow when hovering (desktop only)
     box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2);
 } */
@@ -56,11 +57,11 @@
     margin: 0 0 24px 0;
 }
 
-#firstPercentage { color: #B434ED; }
+#firstPercentage { color: #B434ED }
 
-#secondPercentage { color: #FF4D97; }
+#secondPercentage { color: #FF4D97 }
 
-#thirdPercentage { color: #1B8BF1; }
+#thirdPercentage { color: #1B8BF1 }
 
 .marketingDataText {
     font-size: 16px;
@@ -72,9 +73,18 @@
     margin: 0;
 }
 
-#studySource { padding-bottom: 62px; }
+/* Swiper cards navigation carousel */
 
-@media screen and (max-width: 699px) {
+#carouselWrapper { display: none }
+
+#studySource { 
+  padding-bottom: 62px;
+  text-align: center;
+}
+
+/* Mobile version */
+
+@media screen and (max-width: 939px) {
     #marketingDataTitle { 
       font-size: 24px; 
       
@@ -84,15 +94,68 @@
       padding-top: 40px;
     }
 
-    #marketingDataWrapper { margin-bottom: 16px }
+    #marketingDataWrapper { display: none }
 
-    #marketingDataWrapper > * {
-      flex: 0 1 284px;
+    /* Swiper cards navigation carousel */
+
+    #mySwiper {
+        min-width: 240px;
+        max-width: 284px;
+        height: 420px;
+
+        margin: 0;      
     }
 
-    #marketingDataWrapper > *:nth-child(odd) {
-      display: none;
+    #carouselWrapper {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        margin: 0 24px 24px;
     }
+
+    /* .swiper-wrapper > * {
+        box-sizing: border-box;
+      
+        height: 420px;
+      
+        padding: 141px 23px 0;
+      
+        background: #FAFAFA;
+    } */
+
+    .swiperButton {
+        background-color: #FF4D97;
+
+        width: 44px;
+        height: 44px;
+
+        border-style: none;
+        border-radius: 100%;
+    }
+
+    button#prev, button#next {
+        margin: -22px;
+        z-index: 2;
+        cursor: pointer;
+    }
+
+    button#prev::after, button#next::after {
+        width: 11px;
+        height: 22px;
+
+        font-style: normal;
+        font-weight: 700;
+        font-size: 20px;
+        line-height: 22px;
+        text-align: center;
+        color: #FFF;
+    }
+
+    button#prev::after { content: '<' }
+
+    button#next::after { content: '>' }
+
+    /* .swiper-button-prev, .swiper-button-next { display: none } */
 
     .marketingDataText {
       text-align: center;
@@ -103,7 +166,7 @@
     }
 
     #studySource { 
-      width: 234px;
+      width: auto;
 
       text-align: center;
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,5 +1,9 @@
 @import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
 
+* {
+  font-family: 'Poppins';
+}
+
 body{
   margin: 0;
 }
@@ -7,3 +11,21 @@ body{
 html{
   scroll-behavior: smooth;
 }
+
+/* MarketingData component: Swiper cards navigation carousel rules 
+   It was necessary to include this styling here, because NextJS
+   wasn't accepting those changes in the component '.module.css' */
+
+.swiper-wrapper > * {
+  box-sizing: border-box;
+
+  height: 420px;
+
+  padding: 141px 23px 0;
+
+  background: #FAFAFA;
+}
+
+/* Important in order to override swiper navigation.min.css rules */
+
+.swiper-button-prev, .swiper-button-next { display: none !important }


### PR DESCRIPTION
# Components transition

## Contact component

Contact component is finally here, fully responsive.
I changed the layout breakpoints from 699px to 939px, in order to keep it up with the other components breakpoints (999px). 
I haven't choose the 999px breakpoint because of the shrink factor on the cards at the Marketing Data component: **when the page hits 939px, the cards reach their minimum designed width of 284px**.

## MarketingData component

As you have wondered, here's my solution for the Marketing Data component **interactive carousel**. I used **Swiper** to make it happen as smooth as possible. 
Unfortunately, overlapping buttons on a swiper navigation is a tricky task: I had to create individual buttons outside the Swiper component. They contain an `onClick` attribute that triggers the `useRef` hook, in order to make they work alongside the Swiper `onBeforeInit` attribute.

Styling was particulary also tricky, given the NextJs limitations for styling pure elements (It **MUST** has a `class` or an `id`).

# Other changes

I've included the Poppins font-family inside the global css file, to avoid repetitions on every component. **I think we should just lapidate the page by removing every font-family occurrency.**

Besides that, there were only few code organization, renaming and layout changes at Contact component for higher design fidelity.

# Next steps
- [x] Implement controlled components on the Contact component formulary
- [ ] Develop an e-mail validation on the Contact component formulary
- [ ] Work on the auto-resize function for the `textarea` element input on the Contact component formulary